### PR TITLE
Add button to open note location in file explorer

### DIFF
--- a/lib/view/screens/note_editor.dart
+++ b/lib/view/screens/note_editor.dart
@@ -35,6 +35,10 @@ bool isDesktop(BuildContext context) {
   return MediaQuery.of(context).size.width >= 800;
 }
 
+bool isMobile() {
+  return !Platform.isWindows && !Platform.isLinux && !Platform.isMacOS;
+}
+
 class _NoteEditorScreenState extends State<NoteEditorScreen> {
   late TextEditingController _titleController;
   late TextEditingController _notesController;
@@ -79,6 +83,12 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
         "open",
         [path],
         workingDirectory: path,
+      );
+    }
+
+    if (isMobile()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        customSnackBar('Currently not supported on mobile'),
       );
     }
 
@@ -240,9 +250,14 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
             ),
             IconButton(
               icon: Icon(Icons.folder_open,
-                  color: Theme.of(context).colorScheme.onSurface),
+                  color: !isMobile()
+                      ? Theme.of(context).colorScheme.onSurface
+                      : Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withOpacity(0.5)),
               tooltip: 'Open Note Location',
-              onPressed: () async => await _openExplorer(),
+              onPressed: () async => !isMobile() ? await _openExplorer() : null,
             ),
           ],
         ),

--- a/lib/view/screens/note_editor.dart
+++ b/lib/view/screens/note_editor.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:keyboard_attachable/keyboard_attachable.dart';
 import 'package:markdown_widget/markdown_widget.dart';
-
 import 'package:printnotes/utils/handlers/item_rename.dart';
 import 'package:printnotes/view/components/markdown/build_markdown.dart';
-import 'package:printnotes/view/components/markdown/toolbar/markdown_toolbar.dart';
 import 'package:printnotes/view/components/markdown/editor_field.dart';
+import 'package:printnotes/view/components/markdown/toolbar/markdown_toolbar.dart';
 import 'package:printnotes/view/components/widgets/custom_snackbar.dart';
 
 class NoteEditorScreen extends StatefulWidget {
@@ -55,6 +55,34 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
     _notesController = TextEditingController();
     _loadNoteContent();
     super.initState();
+  }
+
+  Future<bool> _openExplorer(BuildContext context) async {
+    final file = File(widget.filePath);
+    final path = file.parent.path;
+    if (Platform.isLinux) {
+      Process.run(
+        "xdg-open",
+        [path],
+        workingDirectory: path,
+      );
+    }
+    if (Platform.isWindows) {
+      Process.run(
+        "explorer",
+        [path],
+        workingDirectory: path,
+      );
+    }
+    if (Platform.isMacOS) {
+      Process.run(
+        "open",
+        [path],
+        workingDirectory: path,
+      );
+    }
+
+    return true;
   }
 
   Future<void> _loadNoteContent() async {
@@ -209,6 +237,12 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
               tooltip: 'Save Note',
               onPressed: () async =>
                   _isDirty ? await _saveNoteContent(context) : null,
+            ),
+            IconButton(
+              icon: Icon(Icons.folder_open,
+                  color: Theme.of(context).colorScheme.onSurface),
+              tooltip: 'Open Note Location',
+              onPressed: () async => await _openExplorer(context),
             ),
           ],
         ),

--- a/lib/view/screens/note_editor.dart
+++ b/lib/view/screens/note_editor.dart
@@ -57,7 +57,7 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
     super.initState();
   }
 
-  Future<bool> _openExplorer(BuildContext context) async {
+  Future<bool> _openExplorer() async {
     final file = File(widget.filePath);
     final path = file.parent.path;
     if (Platform.isLinux) {
@@ -242,7 +242,7 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
               icon: Icon(Icons.folder_open,
                   color: Theme.of(context).colorScheme.onSurface),
               tooltip: 'Open Note Location',
-              onPressed: () async => await _openExplorer(context),
+              onPressed: () async => await _openExplorer(),
             ),
           ],
         ),


### PR DESCRIPTION
Introduced a new feature that allows users to open the note's directory in their system's file explorer. This enhancement supports Linux, Windows, and macOS platforms and is accessible via a new icon button on the editor's toolbar.


This is my first work with flutter and dart.